### PR TITLE
allow inject.js on all urls

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,7 +18,7 @@
   "web_accessible_resources": [
     {
       "resources": ["connect-web-interceptor.js", "inject.js"],
-      "matches": ["https://*/*"]
+      "matches": ["<all_urls>"]
     }
   ],
   "content_scripts": [


### PR DESCRIPTION
extension would not load on localhost, producion the following error: `content-script.js:8 GET chrome-extension://invalid/ net::ERR_FAILED`